### PR TITLE
Make shaders usable in with-statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@
 - [1.3.0](#onethreezero)
 - [1.4.0](#onefourzero)
 - [1.4.1](#onefourone)
+- [1.4.2](#onefourtwo)
+
+<a name="onefourtwo"/>
+### Pyshaders 1.4.2
+
+- ##### Main module
+	- Added context manager to shader. Use `with shader.using():`. Can be nested.
 
 <a name="onefourone"/>
 ### Pyshaders 1.4.1

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ License
 >MIT License
 
 >Copyright (c) 2016 Gabriel Dubé
+>Copyright (c) 2020 George Zhang
 
 >Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -199,10 +199,16 @@ print(shader, shader2, sep=", ")
 ```
 
 
-To use or remove a shaderprogram, simply call
+To use or remove a shaderprogram, simply do
 ```python
 shader.use()
+# do stuff
 ShaderProgram.clear() # or shader.clear()
+
+# or
+
+with shader.using():
+    # do stuff
 ```
 
 **What happens during the compilation?**

--- a/pyshaders.py
+++ b/pyshaders.py
@@ -2,7 +2,8 @@
 """
 ''MIT License
 
-Copyright (c) 2016 Gabriel Dubé, George Zhang
+Copyright (c) 2016 Gabriel Dubé
+Copyright (c) 2020 George Zhang
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pyshaders.py
+++ b/pyshaders.py
@@ -735,11 +735,16 @@ class ShaderProgram(object):
     @contextmanager
     def using(self):
         " Return a context manager to use the shader program in the with-block "
+        previous = current_program()
+        if previous is not None:
+            previous.clear()
         self.use()
         try:
             yield
         finally:
             self.clear()
+            if previous is not None:
+                previous.use()
     
     def __bool__(self):
         return self.valid()

--- a/pyshaders.py
+++ b/pyshaders.py
@@ -2,7 +2,7 @@
 """
 ''MIT License
 
-Copyright (c) 2016 Gabriel Dubé
+Copyright (c) 2016 Gabriel Dubé, George Zhang
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -52,6 +52,7 @@ from ctypes import c_char, c_uint, cast, POINTER, pointer, byref
 import weakref, itertools
 from collections import namedtuple
 from collections.abc import Sequence
+from contextlib import contextmanager
 
 from sys import modules
 from importlib import import_module
@@ -730,6 +731,16 @@ class ShaderProgram(object):
         " Remove the current shader program "
         glUseProgram(0)
         
+    
+    @contextmanager
+    def using(self):
+        " Return a context manager to use the shader program in the with-block "
+        self.use()
+        try:
+            yield
+        finally:
+            self.clear()
+    
     def __bool__(self):
         return self.valid()
         

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ else:
    
 
 setup(name='pyshaders',
-      version='1.4.1',
+      version='1.4.2',
       description='OpenGL shader wrapper for python',
       author='Gabriel Dubé',
       author_email='gdube@azanka.ca',

--- a/test.py
+++ b/test.py
@@ -290,7 +290,48 @@ class TestShaderPrograms(unittest.TestCase):
         prog.use()
         self.assertEqual(current_program(), prog, 'Program is not in use')
         ShaderProgram.clear()
-        self.assertIsNone(current_program(), 'Current program is not None')        
+        self.assertIsNone(current_program(), 'Current program is not None')
+        
+    def test_using(self):
+        " Test shader with-block "
+        prog = ShaderProgram.new_program()
+        prog.attach(*self.get_objects())
+        prog.link()
+        self.assertIsNone(current_program(), 'Current program is not None')
+        with prog.using():
+            self.assertEqual(current_program(), prog, 'Program is not in use')
+        self.assertIsNone(current_program(), 'Current program is not None')
+        
+    def test_using_nested(self):
+        " Test nested shader with-block "
+        prog = ShaderProgram.new_program()
+        prog.attach(*self.get_objects())
+        prog.link()
+        self.assertIsNone(current_program(), 'Current program is not None')
+        with prog.using():
+            self.assertEqual(current_program(), prog, 'Program is not in use')
+            with prog.using():
+                self.assertEqual(current_program(), prog, 'Program is not in use')
+            self.assertEqual(current_program(), prog, 'Program is not in use')
+        self.assertIsNone(current_program(), 'Current program is not None')
+        
+    def test_using_multiple(self):
+        " Test multiple shaders with-block "
+        prog1 = ShaderProgram.new_program()
+        prog1.attach(*self.get_objects())
+        prog1.link()
+        
+        prog2 = ShaderProgram.new_program()
+        prog2.attach(*self.get_objects('shader2'))
+        prog2.link()
+        
+        self.assertIsNone(current_program(), 'Current program is not None')
+        with prog1.using():
+            self.assertEqual(current_program(), prog1, 'Program 1 is not in use')
+            with prog2.using():
+                self.assertEqual(current_program(), prog2, 'Program 2 is not in use')
+            self.assertEqual(current_program(), prog1, 'Program 1 is not in use')
+        self.assertIsNone(current_program(), 'Current program is not None')
         
 class TestAccessors(unittest.TestCase):
 


### PR DESCRIPTION
Added a `ShaderProgram.using` function that returns a context manager that calls `.use()` and `.clear()`.
```py
with shader.using():
    pyglet.graphics.draw(4, GL_QUADS,
        ("v2f", [0.5, 0.5, 0.75, 0.5, 0.75, 0.75, 0.5, 0.75]),
        ("t2f", [0, 0, 1, 0, 1, 1, 0, 1]),
    )
```

Note: I chose not to directly have `with shader:` as that would prevent nesting of them. I'm not sure of any use cases but it might be a good thing to have. An alternative would to just call `.use()` in `__enter__` and `.clear()` in `__exit__`.
```py
with general.using():
    # draw something
    with specific.using():
        # draw something
```